### PR TITLE
add task for windows-base-105: Disable SMB1 to Windows Shares

### DIFF
--- a/tasks/access.yml
+++ b/tasks/access.yml
@@ -32,6 +32,13 @@
     data: "0"
     type: dword
 
+- name: Disable SMB1 to Windows Shares | windows-base-105
+  win_regedit:
+    path: HKLM:\System\CurrentControlSet\Services\LanManServer\Parameters
+    name: "SMB1"
+    data: "0"
+    type: dword
+
 - name: Strong Windows NTLMv2 Authentication Enabled; Weak LM Disabled | windows-base-201
   win_regedit:
     path: HKLM:\System\CurrentControlSet\Control\Lsa


### PR DESCRIPTION
Adds a task to access.yml to meet the hardening criteria for windows-base-105.

Sets HKLM:\System\CurrentControlSet\Services\LanManServer\Parameters\SMB1 to dword=0