### PR TITLE
Removes " escaping

### DIFF
--- a/tasks/audit.yml
+++ b/tasks/audit.yml
@@ -28,7 +28,7 @@
     type: dword
 
 - name: Account Logon Audit Log | windows-audit-203
-  win_command: AuditPol /Set /Category:\"Account Logon\" /Failure:Enable /Success:Enable
+  win_command: AuditPol /Set /Category:"Account Logon" /Failure:Enable /Success:Enable
   register: accountLogonAudit
   args:
     creates: C:\accountLogonAudit.lock
@@ -41,7 +41,7 @@
   when: accountLogonAudit
 
 - name: Audit Application Group Management | windows-audit-204
-  win_command: AuditPol /Set /SubCategory:\"Application Group Management\" /Failure:Enable /Success:Enable
+  win_command: AuditPol /Set /SubCategory:"Application Group Management" /Failure:Enable /Success:Enable
   register: appGroupMngmtAudit
   args:
     creates: C:\appGroupMngmtAudit.lock
@@ -54,7 +54,7 @@
   when: appGroupMngmtAudit
 
 - name: Audit Computer Account Management | windows-audit-205
-  win_command: AuditPol /Set /SubCategory:\"Computer Account Management\" /Failure:Enable /Success:Enable
+  win_command: AuditPol /Set /SubCategory:"Computer Account Management" /Failure:Enable /Success:Enable
   register: appAccountMngmtAudit
   args:
     creates: C:\appAccountMngmtAudit.lock
@@ -68,7 +68,7 @@
 
 
 - name: Audit Application Group Management | windows-audit-206
-  win_command: AuditPol /Set /SubCategory:\"Distribution Group Management\" /Failure:Enable /Success:Enable
+  win_command: AuditPol /Set /SubCategory:"Distribution Group Management" /Failure:Enable /Success:Enable
   register: distGroupMngmtAudit
   args:
     creates: C:\distGroupMngmtAudit.lock


### PR DESCRIPTION
These commands did not work with character escaping, when running this with Ansible 2.7.5 with python 3.6.7 resulted in the following when running against Windows Server 2016: 

```
TASK [ansible-windows-hardening : Account Logon Audit Log | windows-audit-203] *****************
fatal: [*****]: FAILED! => {"changed": true, "cmd": "AuditPol /Set /Category:\\\"Account Logon\\\" /Failure:Enable /Success:Enable", "delta": "0:00:00.174342", "end": "2019-01-15 01:28:32.731575", "msg": "non-zero return code", "rc": 87, "start": "2019-01-15 01:28:32.557233", "stderr": "Error 0x00000057 occurred:\r\r\nThe parameter is incorrect.\r\r\n\r\r\n", "stderr_lines": ["Error 0x00000057 occurred:", "", "The parameter is incorrect.", "", "", ""], "stdout": "Usage: AuditPol command [<sub-command><options>]\r\r\n\r\r\n\r\r\nCommands (only one command permitted per execution)\r\r\n  /?               Help (context-sensitive)\r\r\n  /get             Displays the current audit policy.\r\r\n  /set             Sets the audit policy.\r\r\n  /list            Displays selectable policy elements.\r\r\n  /backup          Saves the audit policy to a file.\r\r\n  /restore         Restores the audit policy from a file.\r\r\n  /clear           Clears the audit policy.\r\r\n  /remove          Removes the per-user audit policy for a user account.\r\r\n  /resourceSACL    Configure global resource SACLs\r\r\n\r\r\n\r\r\nUse AuditPol <command> /? for details on each command\r\r\n", "stdout_lines": ["Usage: AuditPol command [<sub-command><options>]", "", "", "", "", "", "Commands (only one command permitted per execution)", "", "  /?               Help (context-sensitive)", "", "  /get             Displays the current audit policy.", "", "  /set             Sets the audit policy.", "", "  /list            Displays selectable policy elements.", "", "  /backup          Saves the audit policy to a file.", "", "  /restore         Restores the audit policy from a file.", "", "  /clear           Clears the audit policy.", "", "  /remove          Removes the per-user audit policy for a user account.", "", "  /resourceSACL    Configure global resource SACLs", "", "", "", "", "", "Use AuditPol <command> /? for details on each command", ""]}
```

With this change, these commands work. 

```
TASK [ansible-windows-hardening : Account Logon Audit Log | windows-audit-203] *****************
changed: [*****]
```
