### PR TITLE
Change default SeTrustedCredManAccessPrivilege

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ These roles ensure that a Windows 2012 R2 or Windows 2016 system is compliant wi
 | `win_security_SeRemoteInteractiveLogonRight`   | `*S-1-5-32-544` | Determines which users or groups can access the logon screen of a remote computer through a RDP connection. Default: Administrators |
 | `win_security_SeTcbPrivilege`                  | `*S-1-0-0`      | Allows a process to authenticate like a user and thus gain access to the same resources as a user. Default: Nobody |
 | `win_security_SeMachineAccountPrivilege`       | `*S-1-5-32-544` | Allows the user to add a computer to a specific domain. Default: Administrators |
-| `win_security_SeTrustedCredManAccessPrivilege` | `*S-1-0-0`      | Access Credential Manager as a trusted caller policy setting is used by Credential Manager during backup and restore. Default: Nobody |
+| `win_security_SeTrustedCredManAccessPrivilege` | ``              | Access Credential Manager as a trusted caller policy setting is used by Credential Manager during backup and restore. Default: No One |
 | `win_security_SeNetworkLogonRight`             | `*S-1-0-0`      | Required for an account to log on using the network logon type. Default: Nobody |
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,5 +14,5 @@ win_security_LockoutDuration: 15
 win_security_SeRemoteInteractiveLogonRight: '*S-1-5-32-544'
 win_security_SeTcbPrivilege: '*S-1-0-0'
 win_security_SeMachineAccountPrivilege: '*S-1-5-32-544'
-win_security_SeTrustedCredManAccessPrivilege: '*S-1-0-0'
+win_security_SeTrustedCredManAccessPrivilege: ''
 win_security_SeNetworkLogonRight: '*S-1-0-0'


### PR DESCRIPTION
Currently executing the inspec windows baseline fails due to a control change. This changes the default setting for `SeTrustedCredManAccessPrivilege` to reflect this.

The 'SeTrustedCredManAccessPrivilege' should be granted to 'No One'
instead of the Nobody 'S-1-0-0' well-known-SID. This was changed
in the Windows Baseline.

See https://github.com/dev-sec/windows-baseline/pull/23

Signed-off-by: James Meakin <code@jmsmkn.com>